### PR TITLE
fix: migrate 'semver' module to std

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.142.0/http/server.ts";
-import { gt } from "https://deno.land/x/semver/mod.ts"
+import { gt } from "https://deno.land/std/semver/mod.ts"
 import { createHash } from "https://deno.land/std@0.142.0/hash/mod.ts";
 
 


### PR DESCRIPTION
The 'semver' module has been migrated to the standard library https://deno.land/std/semver