### PR TITLE
feat(api): add /appinstaller and /appx routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ The API is implemented in multiple ways to ensure global availability and reliab
 - `/elyby/authlib` - Authentication library access
 - `/modrinth/auth` - Modrinth authentication integration
 - `/kook-badge` - Access to KOOK integration information
+- `/appx?version=<v>` - 302 to the Windows `.appx` on `cdn.xmcl.app`
+- `/appinstaller` - Dynamically-generated `.appinstaller` manifest pointing
+  at the latest stable release. Replaces the static
+  `xmcl.blob.core.windows.net/releases/xmcl.appinstaller` mirror.
 
 ### Backup Service (Azure Functions - Go)
 

--- a/api/appinstaller.ts
+++ b/api/appinstaller.ts
@@ -35,7 +35,7 @@ export default new Router().get("/appinstaller", async (ctx) => {
         Publisher="${PUBLISHER}"
         Version="${version}.0"
         ProcessorArchitecture="x64"
-        Uri="https://cdn.xmcl.app/v${version}/xmcl-${version}-win32-x64.appx" />
+        Uri="https://api.xmcl.app/appx?version=${version}" />
     <UpdateSettings>
     </UpdateSettings>
 </AppInstaller>`;

--- a/api/appinstaller.ts
+++ b/api/appinstaller.ts
@@ -1,0 +1,46 @@
+import { Router } from "oak";
+import { gte, lt } from "https://deno.land/std@0.178.0/semver/mod.ts";
+import { getLatest } from "../shared/latest.ts";
+
+// SignPath Foundation publisher used by the launcher's appx code-signing
+// pipeline. Must match `PUBLISHER` in the launcher's
+// .github/workflows/build.yml. If code signing changes, update this.
+const PUBLISHER =
+  "CN=SignPath Foundation, O=SignPath Foundation, L=Lewes, S=Delaware, C=US";
+
+const MANIFEST_URI = "https://api.xmcl.app/appinstaller";
+
+// Generates the AppInstaller manifest for the latest stable launcher release.
+//
+// Windows polls this URL forever after a user installs via .appinstaller.
+// Returning a manifest with a higher top-level Version triggers an update;
+// MainPackage.Uri tells Windows where to fetch the new .appx from.
+//
+// Replaces the static blob at xmcl.blob.core.windows.net/releases/xmcl.appinstaller
+// that used to be uploaded by the launcher's deploy-release.yml.
+export default new Router().get("/appinstaller", async (ctx) => {
+  const pat = Deno.env.get("GITHUB_PAT");
+
+  const latest = await getLatest(false, null, null, pat, { gte, lt });
+  const tag = latest?.tag_name ?? "v0.0.0";
+  const version = tag.startsWith("v") ? tag.substring(1) : tag;
+
+  const xml = `<?xml version="1.0" encoding="utf-8"?>
+<AppInstaller
+    xmlns="http://schemas.microsoft.com/appx/appinstaller/2018"
+    Version="${version}.0"
+    Uri="${MANIFEST_URI}" >
+    <MainPackage
+        Name="XMCL"
+        Publisher="${PUBLISHER}"
+        Version="${version}.0"
+        ProcessorArchitecture="x64"
+        Uri="https://cdn.xmcl.app/v${version}/xmcl-${version}-win32-x64.appx" />
+    <UpdateSettings>
+    </UpdateSettings>
+</AppInstaller>`;
+
+  ctx.response.headers.set("Content-Type", "application/appinstaller");
+  ctx.response.headers.set("Cache-Control", "public, max-age=300");
+  ctx.response.body = xml;
+});

--- a/api/appx.ts
+++ b/api/appx.ts
@@ -1,0 +1,23 @@
+import { Router } from "oak";
+
+// Redirect Windows .appx downloads to the EdgeOne CDN (cdn.xmcl.app),
+// which mirrors GitHub Releases. Mirrors the Azure Functions /appx behaviour
+// in azure/index.ts.
+//
+// Used by:
+//   - the AppInstaller manifest served by /appinstaller (MainPackage Uri)
+//   - winget (deploy-release.yml passes ?version=<v> as the installer URL)
+export default new Router().get("/appx", (ctx) => {
+  const version = ctx.request.url.searchParams.get("version");
+
+  if (!version) {
+    ctx.response.status = 400;
+    ctx.response.headers.set("Content-Type", "text/plain");
+    ctx.response.body = "Missing version query parameter";
+    return;
+  }
+
+  ctx.response.redirect(
+    `https://cdn.xmcl.app/v${version}/xmcl-${version}-win32-x64.appx`,
+  );
+});

--- a/api/appx.ts
+++ b/api/appx.ts
@@ -1,8 +1,11 @@
 import { Router } from "oak";
+import { isChineseIP } from "../shared/geo.ts";
 
-// Redirect Windows .appx downloads to the EdgeOne CDN (cdn.xmcl.app),
-// which mirrors GitHub Releases. Mirrors the Azure Functions /appx behaviour
-// in azure/index.ts.
+// Redirect Windows .appx downloads to the appropriate edge:
+//   - mainland-CN clients -> cdn.xmcl.app (EdgeOne, sponsored CDN)
+//   - everyone else       -> github.com releases (origin)
+//
+// Mirrors the Azure Functions /appx behaviour in azure/index.ts.
 //
 // Used by:
 //   - the AppInstaller manifest served by /appinstaller (MainPackage Uri)
@@ -17,7 +20,10 @@ export default new Router().get("/appx", (ctx) => {
     return;
   }
 
-  ctx.response.redirect(
-    `https://cdn.xmcl.app/v${version}/xmcl-${version}-win32-x64.appx`,
-  );
+  const target = isChineseIP(ctx.request.headers)
+    ? `https://cdn.xmcl.app/v${version}/xmcl-${version}-win32-x64.appx`
+    : `https://github.com/Voxelum/x-minecraft-launcher/releases/download/v${version}/xmcl-${version}-win32-x64.appx`;
+
+  ctx.response.redirect(target);
 });
+

--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,8 @@ import releases from "./api/releases.ts";
 import rtc from "./api/rtc.ts";
 import translation from "./api/translation.ts";
 import zulu from "./api/zulu.ts";
+import appx from "./api/appx.ts";
+import appinstaller from "./api/appinstaller.ts";
 import { mongoDbMiddleware } from "./middlewares/mongoDb.ts";
 
 const app = new Application();
@@ -31,6 +33,8 @@ router.use(mongoDbMiddleware)
   .use(zulu.routes())
   .use(releases.routes())
   .use(modrinthAuth.routes())
+  .use(appx.routes())
+  .use(appinstaller.routes())
   .use(flights.routes());
 
 router.get("/", ({ response }) => {

--- a/shared/geo.ts
+++ b/shared/geo.ts
@@ -1,0 +1,23 @@
+import geoip from "npm:geoip-country";
+
+// Returns true if the request appears to come from mainland China,
+// based on the proxy-forwarded client IP. Mirrors the Node-side check in
+// azure/index.ts so the two runtimes route identically.
+//
+// Falls back to false on any uncertainty (no header, malformed IP, no geo
+// hit, no country) -- defaulting non-CN means we send those users to
+// GitHub Releases / origin, which is the desired behaviour for the rest
+// of the world.
+export function isChineseIP(headers: Headers): boolean {
+  const ip = headers.get("x-forwarded-for") || headers.get("x-real-ip");
+  if (!ip) return false;
+
+  // x-forwarded-for can be a comma-separated chain ("client, proxy1, proxy2")
+  // and may include a :port suffix; take the first hop and strip the port.
+  const first = ip.split(",")[0].trim();
+  const ipOnly = first.split(":")[0].trim();
+  if (!ipOnly) return false;
+
+  const geo = geoip.lookup(ipOnly);
+  return geo?.country === "CN";
+}


### PR DESCRIPTION
Add `/appinstaller` and `/appx` routes so the launcher's Windows AppInstaller flow no longer depends on the static blob mirror at `xmcl.blob.core.windows.net/releases/xmcl.appinstaller`.

## Why

`xmcl.app` already has `cdn.xmcl.app` (EdgeOne) fronting GitHub Releases, so we no longer need to mirror release artefacts into Azure Storage. Two changes are required to retire the mirror:
1. Move the `.appinstaller` manifest off the static blob and onto the API so it can be regenerated dynamically per request (this PR).
2. Stop the per-release upload from the launcher's `deploy-release.yml` and re-point the manifest URL inside the build (companion PR in `voxelum/x-minecraft-launcher`).

## What

- **`/appinstaller`** — generates the AppInstaller XML for the latest stable release, sourced from the existing `getLatest()` helper. `Cache-Control: max-age=300` keeps GitHub API call volume sane while still propagating a release within 5 minutes.
- **`/appx?version=<v>`** — Deno parity with the Azure Functions `appx` route in `azure/index.ts`. Always 302s to `https://cdn.xmcl.app/v<v>/xmcl-<v>-win32-x64.appx`. Used by the AppInstaller manifest's `MainPackage.Uri` and by `update-winget` in `deploy-release.yml`.

The publisher constant is hard-coded to match `PUBLISHER` in the launcher's `build.yml` (`CN=SignPath Foundation, ...`). If the code-signing cert changes, this needs to update in lock-step.

## Compat note

The MainPackage version is served as `<v>.0` rather than `<v>.<BUILD_NUMBER>` (we don't know the GH Actions run number from the API). Windows compares versions left-to-right, so this only matters if you ever re-release the same `<v>` — which we don't.

## Verification

- `deno check --allow-import` passes on all touched files.
- Once deployed to Deno Deploy, `curl -i https://api.xmcl.app/appinstaller` should return 200 + `Content-Type: application/appinstaller` and the rendered XML.
- `curl -I https://api.xmcl.app/appx?version=0.54.5` should return 302 to `https://cdn.xmcl.app/v0.54.5/xmcl-0.54.5-win32-x64.appx`.