### PR TITLE
ci(azure): auto-deploy xmcl-core-api on push to main

### DIFF
--- a/.github/workflows/main_xmcl-core-api.yml
+++ b/.github/workflows/main_xmcl-core-api.yml
@@ -4,11 +4,17 @@
 name: Build and deploy Deno project to Azure Function App - xmcl-core-api
 
 on:
-  # push:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - 'azure/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'azure/**'
+      - 'shared/**'
+      - 'build.ts'
+      - 'deno.json'
+      - 'deno.lock'
+      - 'host.json'
+      - '.github/workflows/main_xmcl-core-api.yml'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Re-enables the `push` trigger on `main_xmcl-core-api.yml` so `xmcl-core-api` auto-deploys from `main`. Today the trigger is commented out, so:

- Deno Deploy (`api.xmcl.app`) auto-deploys from `main` ✅
- Azure Functions backup (`xmcl-core-api.azurewebsites.net`) only updates when the maintainer right-clicks "Deploy to Function App" in VS Code (last 3 deploys per `az resource show .../deployments`: all `ms-azuretools-vscode`, on 2025-08-13 ×2 and 2025-10-05).

After #5 merged, the new `/appx` and `/appinstaller` routes only landed on Deno Deploy. The two backends drift from each other until someone remembers to push from VS Code.

## Path filter

I expanded the original commented-out `paths: ['azure/**']` to cover everything `build.ts` actually bundles into `azure/index.js`:

| Path | Why |
| --- | --- |
| `azure/**` | the entry + handlers |
| `shared/**` | imported by `azure/index.ts` (`shared/latest.ts`, `shared/notifications.ts`, `shared/flights.ts`, the new `shared/geo.ts`) |
| `build.ts` | the esbuild script |
| `deno.json` / `deno.lock` | import map + lockfile |
| `host.json` | Functions runtime config |
| this workflow file | self |

`workflow_dispatch` is preserved so you can still trigger by hand.

## Verification

After merging, the next push to `main` touching any of the above paths should kick off a run that builds with Deno 2.3.1, uploads the artifact, OIDC-logins to subscription `d3076e5f-…`, and `Azure/functions-action@v1` deploys to slot `Production` of `xmcl-core-api`.

Once this is in, I'll dispatch one run manually so the `/appx` + `/appinstaller` routes from #5 land on the Azure backup too.