### PR TITLE
fix(ci): install @azure/functions runtime deps before deploy

### DIFF
--- a/.github/workflows/main_xmcl-core-api.yml
+++ b/.github/workflows/main_xmcl-core-api.yml
@@ -40,6 +40,16 @@ jobs:
         run: |
           deno run --allow-net --allow-env --allow-read --allow-run --allow-write build.ts
 
+      - name: 'Install Azure Functions runtime deps'
+        # Deno marks @azure/functions-core as external in build.ts and only
+        # creates an empty node_modules/@azure/functions/ shell, so the v4
+        # Functions host can't load the bundle. Run a real npm install so
+        # node_modules contains @azure/functions + @azure/functions-core,
+        # then they're packaged into the deploy zip.
+        shell: pwsh
+        run: |
+          npm install --no-save --omit=dev --no-package-lock @azure/functions
+
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
First post-#6 auto-deploy fired and succeeded, but the Function App now has **0 registered functions** — `/api/latest`, `/api/flights`, `/api/appx` all 404. Diagnosis from Kudu (`/api/vfs/site/wwwroot/...`):

- `azure/index.js` (335 KB) is present and fresh
- `package.json` correctly has `{"main": "azure/index.js"}`
- `node_modules/@azure/` contains only an **empty** `functions/` directory
- `@azure/functions-core` is missing entirely

Root cause:
- `build.ts` marks `@azure/functions-core` as external for esbuild, on the assumption that the host provides it via `node_modules`.
- Deno's `npm:@azure/functions` resolution creates only the *shell* directory `node_modules/@azure/functions/` because esbuild bundles the contents — Deno never materializes the actual files.
- `@azure/functions-core` is never fetched by anything (it's marked external by esbuild and not imported elsewhere).
- Result: the v4 Functions host loads `azure/index.js`, the bundle's calls into `@azure/functions-core` fail silently, and zero `app.get(...)` registrations land.

VS Code's "Deploy to Function App" historically masked this because it skipped `node_modules` entirely (honoring `.funcignore`) and relied on Azure's server-side `npm install`. Our CI uses `respect-funcignore: false` and `scm-do-build-during-deployment: false`, so we have to ship a complete `node_modules` ourselves.

## Fix

One extra step in the build job:

```yaml
- name: 'Install Azure Functions runtime deps'
  shell: pwsh
  run: |
    npm install --no-save --omit=dev --no-package-lock @azure/functions
```

`npm install` pulls a complete `@azure/functions` plus its transitive `@azure/functions-core` into `node_modules/`, which then gets included in the zip uploaded by `Azure/functions-action@v1`. The `--no-save --no-package-lock` flags keep the package.json shim untouched (so Aliyun/Deno paths aren't disturbed).

## Verification plan

After this merges:
1. CI runs and reports `Successfully deployed web package to App Service.`
2. `az functionapp function list -g xmcl -n xmcl-core-api` should list `appx`, `flights`, `latest`, `notifications`.
3. `curl -i https://xmcl-core-api.azurewebsites.net/api/latest` should 200 with JSON.
4. `curl -I https://xmcl-core-api.azurewebsites.net/api/appx?version=0.54.5` should 302 to GitHub Releases (or `cdn.xmcl.app` from a CN IP).