### PR TITLE
fix(ci): declare @azure/functions in package.json for v4 model

### DIFF
--- a/.github/workflows/main_xmcl-core-api.yml
+++ b/.github/workflows/main_xmcl-core-api.yml
@@ -41,14 +41,16 @@ jobs:
           deno run --allow-net --allow-env --allow-read --allow-run --allow-write build.ts
 
       - name: 'Install Azure Functions runtime deps'
-        # Deno marks @azure/functions-core as external in build.ts and only
-        # creates an empty node_modules/@azure/functions/ shell, so the v4
-        # Functions host can't load the bundle. Run a real npm install so
-        # node_modules contains @azure/functions + @azure/functions-core,
-        # then they're packaged into the deploy zip.
+        # Azure Functions v4 Node programming model requires @azure/functions
+        # to be declared in package.json#dependencies AND installed in
+        # node_modules; otherwise the host loads azure/index.js but never
+        # discovers the app.get(...) registrations and reports
+        # "0 functions found (Custom)" on startup.
+        # Deno's npm: resolution only creates empty shells (esbuild bundles
+        # the contents), so we have to install for real here.
         shell: pwsh
         run: |
-          npm install --no-save --omit=dev --no-package-lock @azure/functions
+          npm install --omit=dev --no-package-lock
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -1,3 +1,6 @@
 {
-  "main": "azure/index.js"
+  "main": "azure/index.js",
+  "dependencies": {
+    "@azure/functions": "^4.0.0"
+  }
 }


### PR DESCRIPTION
## Why the previous fix wasn't enough

After #7, `node_modules/@azure/functions/` was correctly populated. Verified via Kudu VFS:

```
@azure/
  functions/
    dist/azure-functions.js (181KB)
    dist/azure-functions.min.js (65KB)
    src/, types/, package.json, README.md, LICENSE
```

But the host log on startup still shows:

```
2026-05-10T12:51:22 [Information] Loading functions metadata
2026-05-10T12:51:22 [Information] Reading functions metadata (Custom)
2026-05-10T12:51:22 [Information] 0 functions found (Custom)
2026-05-10T12:51:22 [Information] 0 functions loaded
```

→ The Functions host loads `azure/index.js` but the bundle's `app.get(...)` calls never make it through to function registration.

## Root cause

Per the Microsoft docs, the v4 Node programming model requires **`@azure/functions` to be declared in `package.json#dependencies`** — the host inspects this to switch into v4 mode and to load entry-point registrations. Our shim was just `{"main": "azure/index.js"}`, no `dependencies` block. VS Code's deploys masked this for years because the extension generates a real `package.json`.

## Fix (2 lines + 1 word)

- `package.json`: add the dependency declaration.

  ```json
  {
    "main": "azure/index.js",
    "dependencies": { "@azure/functions": "^4.0.0" }
  }
  ```

- workflow: drop the explicit package name from `npm install` so it just reads `package.json`.

  ```diff
  - npm install --no-save --omit=dev --no-package-lock @azure/functions
  + npm install        --omit=dev --no-package-lock
  ```

## Safety for other deploy paths

- **Deno Deploy / `index.ts`** — reads `deno.json`, ignores `package.json#dependencies`. No change.
- **Aliyun FC** — uses the compiled Deno binary via `aliyun/bootstrap`, doesn't touch package.json. No change.
- **`xmcl-highfreq-function`** — separate repo (`voxelum/xmcl-web-api-backup`), unaffected.

## Verification plan

After this merges:

1. The auto-deploy run should land a new deployment on `xmcl-core-api` (sha matches the merge).
2. `az functionapp function list -g xmcl -n xmcl-core-api` should list `appx`, `flights`, `latest`, `notifications`, `appinstaller` (the new one from #5 also lands here once the bundle includes it — note `azure/index.ts` doesn't yet expose `appinstaller`; that will be a small follow-up if we want parity on Azure too).
3. `curl https://xmcl-core-api.azurewebsites.net/api/latest` should return the GH-release JSON.
4. `curl -I "https://xmcl-core-api.azurewebsites.net/api/appx?version=0.54.5"` should 302 to the geo-appropriate target.