### PR TITLE
fix: install API dependencies for Worker bundle

### DIFF
--- a/.github/workflows/main_xmcl-core-api.yml
+++ b/.github/workflows/main_xmcl-core-api.yml
@@ -27,9 +27,12 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install Cloudflare dependencies
+      - name: Install API dependencies
+        run: npm ci
+
+      - name: Install Cloudflare toolchain
         working-directory: cloudflare
-        run: npm install
+        run: npm install --no-package-lock
 
       - name: Type-check Worker
         working-directory: cloudflare


### PR DESCRIPTION
## Summary
- install root API dependencies before running Wrangler
- retain the Cloudflare-specific toolchain install and deployment step
- resolve missing Hono and semver modules while bundling src/ from cloudflare/worker.ts`n
## Validation
- npm ci
- npm --prefix cloudflare install --no-package-lock
- npx wrangler deploy --dry-run