### PR TITLE
fix: authenticate Modrinth OAuth token exchange

### DIFF
--- a/src/lib/accountRuntime.ts
+++ b/src/lib/accountRuntime.ts
@@ -41,7 +41,9 @@ export async function getAccountRuntime(
     }),
     modrinth: createModrinthOAuth({
       clientId: config.XMCL_MODRINTH_CLIENT_ID,
-      clientSecret: config.XMCL_MODRINTH_CLIENT_SECRET,
+      // Existing Workers use MODRINTH_SECRET. Prefer the XMCL-scoped secret,
+      // but retain the legacy value while deployments migrate.
+      clientSecret: config.XMCL_MODRINTH_CLIENT_SECRET ?? config.MODRINTH_SECRET,
       redirectUris: redirects,
     }),
     google: createGoogleOAuth({

--- a/src/lib/oauth/modrinth.test.ts
+++ b/src/lib/oauth/modrinth.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { createModrinthOAuth, DEFAULT_MODRINTH_CLIENT_ID } from "./modrinth.ts";
 
-Deno.test("uses the configured Modrinth OAuth client and client secret for browser exchange", async () => {
+Deno.test("uses Modrinth's required Authorization client-secret header for browser exchange", async () => {
   const requests: Request[] = [];
   const adapter = createModrinthOAuth({
     redirectUris: ["https://preview.example.invalid/oauth/callback"],
@@ -40,11 +40,11 @@ Deno.test("uses the configured Modrinth OAuth client and client secret for brows
   });
   assert.equal(
     requests[0].headers.get("authorization"),
-    null,
+    "configured-modrinth-secret",
   );
   const form = new URLSearchParams(await requests[0].text());
   assert.equal(form.get("client_id"), "configured-modrinth-client");
-  assert.equal(form.get("client_secret"), "configured-modrinth-secret");
+  assert.equal(form.get("client_secret"), null);
 });
 
 Deno.test("uses the existing registered Modrinth client ID by default", () => {

--- a/src/lib/oauth/modrinth.ts
+++ b/src/lib/oauth/modrinth.ts
@@ -25,6 +25,9 @@ export function createModrinthOAuth(options: {
       launcherAvailable: true,
     },
     clientSecret: options.clientSecret,
+    // Modrinth's token endpoint expects the client secret as the raw
+    // Authorization header, unlike the other OAuth providers.
+    clientSecretLocation: "authorization",
     fetch: options.fetch,
     mapUser: (body) => ({ subject: body.id, displayName: body.username }),
   });

--- a/src/lib/oauth/types.ts
+++ b/src/lib/oauth/types.ts
@@ -73,6 +73,7 @@ export function isOAuthProvider(value: unknown): value is OAuthProvider {
 export interface RemoteOAuthOptions {
   declaration: OAuthProviderDeclaration;
   clientSecret?: string;
+  clientSecretLocation?: "body" | "authorization";
   fetch?: typeof globalThis.fetch;
   mapUser(
     body: Record<string, unknown>,
@@ -82,12 +83,14 @@ export interface RemoteOAuthOptions {
 export class RemoteOAuthAdapter implements OAuthProviderAdapter {
   readonly declaration: OAuthProviderDeclaration;
   private readonly clientSecret?: string;
+  private readonly clientSecretLocation: "body" | "authorization";
   private readonly remoteFetch: typeof globalThis.fetch;
   private readonly mapUser: RemoteOAuthOptions["mapUser"];
 
   constructor(options: RemoteOAuthOptions) {
     this.declaration = options.declaration;
     this.clientSecret = options.clientSecret;
+    this.clientSecretLocation = options.clientSecretLocation ?? "body";
     // Cloudflare's fetch requires the Worker global as its receiver. Keeping an
     // unbound reference works in Node/Deno but throws an illegal-invocation
     // error in Workers when an OAuth adapter calls it later.
@@ -124,13 +127,22 @@ export class RemoteOAuthAdapter implements OAuthProviderAdapter {
       code_verifier: input.codeVerifier,
       redirect_uri: input.redirectUri,
     });
-    if (this.clientSecret) body.set("client_secret", this.clientSecret);
+    const headers: Record<string, string> = {
+      "content-type": "application/x-www-form-urlencoded",
+    };
+    if (this.clientSecret) {
+      if (this.clientSecretLocation === "authorization") {
+        headers.authorization = this.clientSecret;
+      } else {
+        body.set("client_secret", this.clientSecret);
+      }
+    }
 
     let response: Response;
     try {
       response = await this.remoteFetch(this.declaration.tokenEndpoint, {
         method: "POST",
-        headers: { "content-type": "application/x-www-form-urlencoded" },
+        headers,
         body,
         signal: AbortSignal.timeout(PROVIDER_REQUEST_TIMEOUT_MS),
       });


### PR DESCRIPTION
## Summary
- send Modrinth's OAuth client secret in the required Authorization header
- retain a temporary MODRINTH_SECRET fallback while Workers migrate to XMCL_MODRINTH_CLIENT_SECRET
- add token exchange regression coverage

## Validation
- deno test src/lib/oauth/modrinth.test.ts src/lib/oauth/redirectPolicy.test.ts
- deno check OAuth and account runtime modules