### PR TITLE
feat: add LLM gateway authentication APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ All runtimes serve the same routes (defined once in [`src/app.ts`](src/app.ts)):
 - `/prebuilds` - GitHub Actions prebuild workflow runs and artifacts
 - `/v1/auth/*`, `/v1/sessions/*`, `/v1/account/*` - XMCL account, OAuth, and
   session APIs
+- `POST /v1/auth/gateway-token` - Exchanges an authenticated XMCL session for a
+  short-lived RS256 token for offline service verification
+- `GET /.well-known/jwks.json` - Public keys for offline XMCL token verification
+- `GET /llm-pool` - Service-secret-protected tiered LLM routing configuration
 
 ## Environment Variables
 
@@ -149,6 +153,85 @@ The same variables are used across every runtime (read via `hono/adapter`:
 - `CLOUDFLARE_APP_ID` - Cloudflare TURN app id (optional)
 - `XMCL_SESSION_SECRET` - At least 32 characters used to sign XMCL session
   access tokens
+- `XMCL_OFFLINE_JWT_PRIVATE_JWK` - Complete RSA private JWK used to sign
+  short-lived offline-service tokens; set as a Worker secret
+- `XMCL_OFFLINE_JWT_PREVIOUS_PUBLIC_JWKS` - Optional public JWKS containing old
+  verification keys retained during signing-key rotation
+- `XMCL_OFFLINE_JWT_KEY_ID` - Published JWT key id (default:
+  `xmcl-offline-1`)
+- `XMCL_OFFLINE_JWT_ISSUER` - Offline token issuer (default:
+  `https://api.xmcl.app`)
+- `XMCL_OFFLINE_JWT_AUDIENCE` - Offline token audience (default:
+  `xmcl-ai-routing`)
+- `XMCL_OFFLINE_JWT_TTL_SECONDS` - Token lifetime from 60 to 900 seconds
+  (default: 900)
+- `LLM_POOL_SERVICE_SECRET` - Secret required in the `x-service-secret` header
+  by `/llm-pool`
+- `LLM_POOL_SERVICE_HEADER` - Optional service-secret header name override
+- `LLM_POOL_CONFIG` - Secret JSON object keyed by account tier, whose values are
+  arrays of `{ "endpoint", "model", "key" }`
+
+### LLM gateway authentication contract
+
+Clients continue to receive the existing revocable XMCL session token after
+OAuth sign-in. Before calling the LLM gateway, a client exchanges that session:
+
+```http
+POST /v1/auth/gateway-token
+Authorization: Bearer <xmcl-session-token>
+```
+
+```json
+{
+  "accessToken": "<rs256-jwt>",
+  "tokenType": "Bearer",
+  "expiresIn": 900,
+  "expiresAt": "2026-08-04T07:30:00.000Z"
+}
+```
+
+The JWT header is `{ "alg": "RS256", "typ": "at+jwt", "kid": "..." }`.
+Claims include `iss`, `aud`, `sub` (XMCL account id), `sid`, `scope`, `tier`,
+`iat`, and `exp`. `xmcl-ai-routing` validates it locally from
+`/.well-known/jwks.json`; it does not connect to MongoDB. Revoking the original
+XMCL session prevents new gateway tokens, while an already-issued gateway token
+remains valid for at most fifteen minutes. The gateway checks expiry when a
+request starts; an accepted streaming response may continue after token expiry.
+
+The gateway retrieves routing configuration with:
+
+```http
+GET /llm-pool
+X-Service-Secret: <service-secret>
+```
+
+The response is a tier-keyed object:
+
+```json
+{
+  "free": [
+    {
+      "endpoint": "https://api.openai.com",
+      "model": "gpt-4.1-mini",
+      "key": "<provider-key>"
+    }
+  ]
+}
+```
+
+The response uses `Cache-Control: no-store`; the gateway owns the one-hour
+in-memory cache. Provider keys are stored only in the encrypted Worker secret.
+
+Generate a new signing key without writing it to disk:
+
+```sh
+deno run scripts/generateOfflineJwtKey.ts xmcl-offline-2026-08
+```
+
+Set its `privateJwk` as `XMCL_OFFLINE_JWT_PRIVATE_JWK`. During rotation, put the
+old public JWK in `XMCL_OFFLINE_JWT_PREVIOUS_PUBLIC_JWKS`, deploy the new key,
+and retain the old public key for at least the token TTL plus the JWKS cache
+duration.
 - `XMCL_MICROSOFT_CLIENT_ID`, `XMCL_MICROSOFT_CLIENT_SECRET` - Microsoft OAuth
   application credentials
 - `XMCL_MODRINTH_CLIENT_ID`, `XMCL_MODRINTH_CLIENT_SECRET` - Modrinth OAuth
@@ -234,6 +317,11 @@ wrangler queues create xmcl-translation
 # Set secrets (see .dev.vars.example for the full list)
 wrangler secret put MONGO_CONNECION_STRING
 wrangler secret put GITHUB_PAT
+wrangler secret put XMCL_SESSION_SECRET
+wrangler secret put XMCL_OFFLINE_JWT_PRIVATE_JWK
+wrangler secret put XMCL_OFFLINE_JWT_PREVIOUS_PUBLIC_JWKS
+wrangler secret put LLM_POOL_SERVICE_SECRET
+wrangler secret put LLM_POOL_CONFIG
 # ...RTC_SECRET, AGNES_API_KEY, CURSEFORGE_KEY,
 #    MODRINTH_SECRET, CLOUDFLARE_API_TOKEN, CLOUDFLARE_APP_ID
 

--- a/cloudflare/.dev.vars.example
+++ b/cloudflare/.dev.vars.example
@@ -14,3 +14,17 @@ CLOUDFLARE_APP_ID=""
 AGNES_API_KEY=""
 CURSEFORGE_KEY=""
 MODRINTH_SECRET=""
+
+# XMCL account sessions and short-lived RS256 tokens for offline services.
+XMCL_SESSION_SECRET=""
+XMCL_OFFLINE_JWT_PRIVATE_JWK=""
+XMCL_OFFLINE_JWT_PREVIOUS_PUBLIC_JWKS='{"keys":[]}'
+XMCL_OFFLINE_JWT_KEY_ID="xmcl-offline-1"
+XMCL_OFFLINE_JWT_ISSUER="https://api.xmcl.app"
+XMCL_OFFLINE_JWT_AUDIENCE="xmcl-ai-routing"
+XMCL_OFFLINE_JWT_TTL_SECONDS="900"
+
+# Private LLM routing configuration consumed by xmcl-ai-routing.
+LLM_POOL_SERVICE_SECRET=""
+LLM_POOL_SERVICE_HEADER="x-service-secret"
+LLM_POOL_CONFIG='{"free":[{"endpoint":"https://api.openai.com","model":"gpt-4.1-mini","key":"replace-me"}]}'

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -6,11 +6,18 @@ compatibility_flags = ["nodejs_compat"]
 # Non-secret defaults. Secrets (GITHUB_PAT, MONGO_CONNECION_STRING, RTC_SECRET,
 # AGNES_API_KEY, CURSEFORGE_KEY, MODRINTH_SECRET,
 # CLOUDFLARE_API_TOKEN, CLOUDFLARE_APP_ID,
-# XMCL_MULTIPLAYER_TICKET_SECRET) must be set with
+# XMCL_MULTIPLAYER_TICKET_SECRET, XMCL_SESSION_SECRET,
+# XMCL_OFFLINE_JWT_PRIVATE_JWK, LLM_POOL_SERVICE_SECRET,
+# LLM_POOL_CONFIG) must be set with
 # `wrangler secret put <NAME>` or via the dashboard. See .dev.vars.example.
 [vars]
 MONGODB_NAME = "xmcl-api"
 TURNS = ""
+XMCL_OFFLINE_JWT_KEY_ID = "xmcl-offline-1"
+XMCL_OFFLINE_JWT_ISSUER = "https://api.xmcl.app"
+XMCL_OFFLINE_JWT_AUDIENCE = "xmcl-ai-routing"
+XMCL_OFFLINE_JWT_TTL_SECONDS = "900"
+LLM_POOL_SERVICE_HEADER = "x-service-secret"
 
 [[durable_objects.bindings]]
 name = "MULTIPLAYER_ROOM"

--- a/scripts/generateOfflineJwtKey.ts
+++ b/scripts/generateOfflineJwtKey.ts
@@ -1,0 +1,32 @@
+const keyId = Deno.args[0] ||
+  `xmcl-offline-${new Date().toISOString().slice(0, 10)}`;
+const keys = await crypto.subtle.generateKey(
+  {
+    name: "RSASSA-PKCS1-v1_5",
+    modulusLength: 2048,
+    publicExponent: new Uint8Array([1, 0, 1]),
+    hash: "SHA-256",
+  },
+  true,
+  ["sign", "verify"],
+) as CryptoKeyPair;
+const privateJwk = await crypto.subtle.exportKey("jwk", keys.privateKey);
+const publicJwk = await crypto.subtle.exportKey("jwk", keys.publicKey);
+
+console.log(JSON.stringify(
+  {
+    keyId,
+    privateJwk: { ...privateJwk, kid: keyId, alg: "RS256", use: "sig" },
+    publicJwks: {
+      keys: [{
+        ...publicJwk,
+        kid: keyId,
+        alg: "RS256",
+        use: "sig",
+        key_ops: ["verify"],
+      }],
+    },
+  },
+  null,
+  2,
+));

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import group from "./routes/group.ts";
 import multiplayer from "./routes/multiplayer.ts";
 import kookBadge from "./routes/kookBadge.ts";
 import latest from "./routes/latest.ts";
+import llm from "./routes/llm.ts";
 import modrinth from "./routes/modrinth.ts";
 import notifications from "./routes/notifications.ts";
 import prebuilds from "./routes/prebuilds.ts";
@@ -38,6 +39,7 @@ export function createApp(register?: (app: Hono<AppEnv>) => void) {
   register?.(app);
 
   app.route("/", latest);
+  app.route("/", llm);
   app.route("/", releases);
   app.route("/", notifications);
   app.route("/", flights);

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,19 @@ export interface AppConfig {
    */
   TRANSLATION_I18N_BASE?: string;
   XMCL_SESSION_SECRET?: string;
+  /** RSA private JWK used to sign short-lived tokens for offline services. */
+  XMCL_OFFLINE_JWT_PRIVATE_JWK?: string;
+  /** Old public JWKS retained through key rotation and token expiry. */
+  XMCL_OFFLINE_JWT_PREVIOUS_PUBLIC_JWKS?: string;
+  XMCL_OFFLINE_JWT_KEY_ID?: string;
+  XMCL_OFFLINE_JWT_ISSUER?: string;
+  XMCL_OFFLINE_JWT_AUDIENCE?: string;
+  XMCL_OFFLINE_JWT_TTL_SECONDS?: string;
+  /** Shared secret accepted by the private LLM pool endpoint. */
+  LLM_POOL_SERVICE_SECRET?: string;
+  LLM_POOL_SERVICE_HEADER?: string;
+  /** Tier-keyed JSON arrays of endpoint/model/key entries. */
+  LLM_POOL_CONFIG?: string;
   /** Server-only HMAC secret for short-lived multiplayer room admission tickets. */
   XMCL_MULTIPLAYER_TICKET_SECRET?: string;
   XMCL_MICROSOFT_CLIENT_ID?: string;

--- a/src/lib/account.ts
+++ b/src/lib/account.ts
@@ -19,6 +19,7 @@ export interface AccountIdentity {
 export interface Account {
   accountId: string;
   status: AccountStatus;
+  tier?: string;
   createdAt: string;
   identities: AccountIdentity[];
   sessionIds?: string[];
@@ -296,6 +297,7 @@ export class AccountService {
       account = {
         accountId: randomId("acct"),
         status: "active",
+        tier: "free",
         createdAt: this.now().toISOString(),
         identities: [],
       };

--- a/src/lib/accountMerge.test.ts
+++ b/src/lib/accountMerge.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { AccountService, MemoryAccountRepository } from "./account.ts";
+import { AccountMergeService } from "./accountMerge.ts";
+
+Deno.test("account merge preserves a paid source tier", async () => {
+  const repository = new MemoryAccountRepository();
+  const accounts = new AccountService(repository);
+  const destination = await accounts.bindIdentity({
+    identity: { provider: "microsoft", subject: "destination-user" },
+    linkedBy: "web_link",
+  });
+  const source = await accounts.bindIdentity({
+    identity: { provider: "modrinth", subject: "paid-source-user" },
+    linkedBy: "web_link",
+  });
+  source.account.tier = "pro";
+  await repository.saveAccount(source.account);
+
+  const merges = new AccountMergeService(repository);
+  const prepared = await merges.prepare({
+    currentAccountId: destination.account.accountId,
+    verifiedTargetIdentity: {
+      provider: "modrinth",
+      subject: "paid-source-user",
+    },
+    requestId: "request-prepare",
+  });
+  await merges.confirm({
+    currentAccountId: destination.account.accountId,
+    mergeId: prepared.mergeId,
+    confirmed: true,
+    idempotencyKey: "merge-tier",
+    requestId: "request-confirm",
+  });
+
+  const merged = await repository.getAccount(destination.account.accountId);
+  assert.equal(merged?.tier, "pro");
+});

--- a/src/lib/accountMerge.ts
+++ b/src/lib/accountMerge.ts
@@ -129,6 +129,7 @@ export class AccountMergeService {
         )
       ) destination.identities.push(identity);
     }
+    destination.tier = mergedTier(destination.tier, source.tier);
     const now = this.now().toISOString();
     source.status = "merged";
     source.mergedIntoAccountId = destination.accountId;
@@ -187,4 +188,15 @@ export class AccountMergeService {
       updatedAt: time,
     };
   }
+}
+
+function mergedTier(
+  destination: string | undefined,
+  source: string | undefined,
+) {
+  const destinationTier = destination || "free";
+  const sourceTier = source || "free";
+  return destinationTier === "free" && sourceTier !== "free"
+    ? sourceTier
+    : destinationTier;
 }

--- a/src/lib/offlineJwt.ts
+++ b/src/lib/offlineJwt.ts
@@ -1,0 +1,180 @@
+import type { AppConfig } from "../config.ts";
+
+const encoder = new TextEncoder();
+const DEFAULT_ISSUER = "https://api.xmcl.app";
+const DEFAULT_AUDIENCE = "xmcl-ai-routing";
+const DEFAULT_TTL_SECONDS = 900;
+const MAX_TTL_SECONDS = 900;
+
+export interface OfflineTokenPrincipal {
+  accountId: string;
+  sessionId: string;
+  scopes: string[];
+  tier: string;
+}
+
+interface PrivateRsaJwk extends JsonWebKey {
+  kty: "RSA";
+  kid?: string;
+  n: string;
+  e: string;
+  d: string;
+}
+
+export class OfflineJwtService {
+  readonly issuer: string;
+  readonly audience: string;
+  readonly ttlSeconds: number;
+  readonly keyId: string;
+  private readonly privateJwk: PrivateRsaJwk;
+  private readonly previousPublicKeys: ReturnType<typeof publicKey>[];
+  private readonly signingKey: Promise<CryptoKey>;
+
+  constructor(config: AppConfig) {
+    const rawKey = config.XMCL_OFFLINE_JWT_PRIVATE_JWK;
+    if (!rawKey) {
+      throw new Error("XMCL_OFFLINE_JWT_PRIVATE_JWK is not set");
+    }
+    let key: PrivateRsaJwk;
+    try {
+      key = JSON.parse(rawKey) as PrivateRsaJwk;
+    } catch {
+      throw new Error("XMCL_OFFLINE_JWT_PRIVATE_JWK must be valid JSON");
+    }
+    if (
+      key.kty !== "RSA" || !key.n || !key.e || !key.d ||
+      !key.p || !key.q || !key.dp || !key.dq || !key.qi
+    ) {
+      throw new Error(
+        "XMCL_OFFLINE_JWT_PRIVATE_JWK must be a complete RSA key",
+      );
+    }
+
+    this.privateJwk = key;
+    this.keyId = config.XMCL_OFFLINE_JWT_KEY_ID?.trim() ||
+      key.kid?.trim() || "xmcl-offline-1";
+    this.issuer = config.XMCL_OFFLINE_JWT_ISSUER?.trim() || DEFAULT_ISSUER;
+    this.audience = config.XMCL_OFFLINE_JWT_AUDIENCE?.trim() ||
+      DEFAULT_AUDIENCE;
+    this.ttlSeconds = parseTtl(config.XMCL_OFFLINE_JWT_TTL_SECONDS);
+    this.previousPublicKeys = parsePreviousKeys(
+      config.XMCL_OFFLINE_JWT_PREVIOUS_PUBLIC_JWKS,
+      this.keyId,
+    );
+    this.signingKey = crypto.subtle.importKey(
+      "jwk",
+      key,
+      { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+  }
+
+  jwks() {
+    return {
+      keys: [
+        publicKey(this.privateJwk, this.keyId),
+        ...this.previousPublicKeys,
+      ],
+    };
+  }
+
+  async issue(principal: OfflineTokenPrincipal, now = new Date()) {
+    const issuedAt = Math.floor(now.getTime() / 1000);
+    const expiresAt = issuedAt + this.ttlSeconds;
+    const unsigned = `${
+      encodeJson({
+        alg: "RS256",
+        kid: this.keyId,
+        typ: "at+jwt",
+      })
+    }.${
+      encodeJson({
+        iss: this.issuer,
+        aud: this.audience,
+        sub: principal.accountId,
+        sid: principal.sessionId,
+        scope: principal.scopes,
+        tier: principal.tier,
+        iat: issuedAt,
+        exp: expiresAt,
+      })
+    }`;
+    const signature = await crypto.subtle.sign(
+      "RSASSA-PKCS1-v1_5",
+      await this.signingKey,
+      encoder.encode(unsigned),
+    );
+    return {
+      accessToken: `${unsigned}.${encodeBytes(new Uint8Array(signature))}`,
+      tokenType: "Bearer" as const,
+      expiresIn: this.ttlSeconds,
+      expiresAt: new Date(expiresAt * 1000).toISOString(),
+    };
+  }
+}
+
+function publicKey(key: { n: string; e: string }, keyId: string) {
+  return {
+    kty: "RSA",
+    n: key.n,
+    e: key.e,
+    kid: keyId,
+    alg: "RS256",
+    use: "sig",
+    key_ops: ["verify"],
+  };
+}
+
+function parsePreviousKeys(value: string | undefined, currentKeyId: string) {
+  if (!value?.trim()) return [];
+  let jwks: { keys?: Array<Record<string, unknown>> };
+  try {
+    jwks = JSON.parse(value);
+  } catch {
+    throw new Error("XMCL_OFFLINE_JWT_PREVIOUS_PUBLIC_JWKS must be valid JSON");
+  }
+  if (!Array.isArray(jwks.keys)) {
+    throw new Error(
+      "XMCL_OFFLINE_JWT_PREVIOUS_PUBLIC_JWKS must contain a keys array",
+    );
+  }
+  const keyIds = new Set([currentKeyId]);
+  return jwks.keys.map((key) => {
+    const keyId = typeof key.kid === "string" ? key.kid.trim() : "";
+    if (
+      key.kty !== "RSA" || typeof key.n !== "string" ||
+      typeof key.e !== "string" || !keyId || keyIds.has(keyId)
+    ) {
+      throw new Error(
+        "XMCL_OFFLINE_JWT_PREVIOUS_PUBLIC_JWKS contains an invalid or duplicate key",
+      );
+    }
+    keyIds.add(keyId);
+    return publicKey({ n: key.n, e: key.e }, keyId);
+  });
+}
+
+function parseTtl(value: string | undefined) {
+  if (value === undefined || value.trim() === "") return DEFAULT_TTL_SECONDS;
+  const ttl = Number(value);
+  if (!Number.isInteger(ttl) || ttl < 60 || ttl > MAX_TTL_SECONDS) {
+    throw new Error(
+      `XMCL_OFFLINE_JWT_TTL_SECONDS must be between 60 and ${MAX_TTL_SECONDS}`,
+    );
+  }
+  return ttl;
+}
+
+function encodeJson(value: unknown) {
+  return encodeBytes(encoder.encode(JSON.stringify(value)));
+}
+
+function encodeBytes(bytes: Uint8Array) {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(
+    /=+$/,
+    "",
+  );
+}

--- a/src/routes/account.ts
+++ b/src/routes/account.ts
@@ -20,12 +20,14 @@ function providerFrom(c: Context<AppEnv>): OAuthProvider {
 function publicAccount(account: {
   accountId: string;
   status: string;
+  tier?: string;
   createdAt: string;
   deletionEffectiveAt?: string;
 }) {
   return {
     accountId: account.accountId,
     status: account.status,
+    tier: account.tier ?? "free",
     createdAt: account.createdAt,
     ...(account.deletionEffectiveAt
       ? { deletionEffectiveAt: account.deletionEffectiveAt }

--- a/src/routes/llm.test.ts
+++ b/src/routes/llm.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import { AccountService, MemoryAccountRepository } from "../lib/account.ts";
+import { AccountMergeService } from "../lib/accountMerge.ts";
+import type { AccountRuntime } from "../lib/accountRuntime.ts";
+import { SessionService } from "../lib/session.ts";
+import type { AppEnv } from "../types.ts";
+import { createLlmRoutes } from "./llm.ts";
+import type { OAuthRegistry } from "../lib/oauth/types.ts";
+
+const sessionSecret = "fixture-only-session-secret-at-least-32-bytes";
+
+async function fixture() {
+  const repository = new MemoryAccountRepository();
+  const accounts = new AccountService(repository);
+  const binding = await accounts.bindIdentity({
+    identity: { provider: "microsoft", subject: "llm-user" },
+    linkedBy: "web_link",
+  });
+  binding.account.tier = "pro";
+  await repository.saveAccount(binding.account);
+  const sessions = new SessionService(repository, sessionSecret);
+  const session = await sessions.issue(binding.account.accountId);
+  const runtime: AccountRuntime = {
+    accounts,
+    sessions,
+    merges: new AccountMergeService(repository),
+    oauth: {} as OAuthRegistry,
+  };
+  const keys = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+  const privateJwk = await crypto.subtle.exportKey("jwk", keys.privateKey);
+  const env = {
+    XMCL_OFFLINE_JWT_PRIVATE_JWK: JSON.stringify(privateJwk),
+    XMCL_OFFLINE_JWT_KEY_ID: "fixture-key",
+    XMCL_OFFLINE_JWT_ISSUER: "https://issuer.fixture",
+    XMCL_OFFLINE_JWT_AUDIENCE: "xmcl-ai-routing",
+    LLM_POOL_SERVICE_SECRET: "fixture-pool-secret",
+    LLM_POOL_CONFIG: JSON.stringify({
+      pro: [{
+        endpoint: "https://llm.fixture/v1/chat/completions",
+        model: "fixture-model",
+        key: "fixture-provider-key",
+      }],
+    }),
+  };
+  const app = new Hono<AppEnv>();
+  app.route(
+    "/",
+    createLlmRoutes(() => Promise.resolve(runtime), () => env),
+  );
+  return { app, env, session, keys };
+}
+
+Deno.test("gateway token is RS256 and carries the account tier", async () => {
+  const { app, env, session, keys } = await fixture();
+  const response = await app.request(
+    "http://localhost/v1/auth/gateway-token",
+    {
+      method: "POST",
+      headers: { authorization: `Bearer ${session.accessToken}` },
+    },
+    env,
+  );
+  assert.equal(response.status, 200);
+  const body = await response.json() as {
+    accessToken: string;
+    expiresIn: number;
+  };
+  assert.equal(body.expiresIn, 900);
+  const [encodedHeader, encodedClaims, encodedSignature] = body.accessToken
+    .split(".");
+  const header = decodePart(encodedHeader);
+  const claims = decodePart(encodedClaims);
+  assert.equal(header.alg, "RS256");
+  assert.equal(header.kid, "fixture-key");
+  assert.equal(claims.sub, session.accountId);
+  assert.equal(claims.tier, "pro");
+  assert.equal(claims.aud, "xmcl-ai-routing");
+  assert.equal(
+    await crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      keys.publicKey,
+      decodeBytes(encodedSignature),
+      new TextEncoder().encode(`${encodedHeader}.${encodedClaims}`),
+    ),
+    true,
+  );
+});
+
+Deno.test("JWKS publishes only the RSA public key", async () => {
+  const { app, env } = await fixture();
+  const response = await app.request(
+    "http://localhost/.well-known/jwks.json",
+    undefined,
+    env,
+  );
+  assert.equal(response.status, 200);
+  const body = await response.json() as {
+    keys: Array<Record<string, unknown>>;
+  };
+  assert.equal(body.keys[0].kid, "fixture-key");
+  assert.equal(body.keys[0].alg, "RS256");
+  assert.equal(body.keys[0].d, undefined);
+});
+
+Deno.test("LLM pool requires the service secret", async () => {
+  const { app, env } = await fixture();
+  const denied = await app.request("http://localhost/llm-pool", undefined, env);
+  assert.equal(denied.status, 401);
+
+  const response = await app.request(
+    "http://localhost/llm-pool",
+    { headers: { "x-service-secret": "fixture-pool-secret" } },
+    env,
+  );
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("cache-control"), "no-store");
+  const body = await response.json() as {
+    pro: Array<{ model: string }>;
+  };
+  assert.equal(body.pro[0].model, "fixture-model");
+});
+
+function decodePart(value: string) {
+  return JSON.parse(new TextDecoder().decode(decodeBytes(value)));
+}
+
+function decodeBytes(value: string) {
+  const normalized = value.replaceAll("-", "+").replaceAll("_", "/");
+  const binary = atob(
+    normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "="),
+  );
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}

--- a/src/routes/llm.ts
+++ b/src/routes/llm.ts
@@ -1,0 +1,141 @@
+import type { Context } from "hono";
+import { Hono } from "hono";
+import { type AppConfig, getConfig } from "../config.ts";
+import { AccountError } from "../lib/account.ts";
+import { handleAccountError } from "../lib/accountHttp.ts";
+import { getAccountRuntime } from "../lib/accountRuntime.ts";
+import { OfflineJwtService } from "../lib/offlineJwt.ts";
+import type { AccountRuntimeResolver } from "../middleware/xmclAuth.ts";
+import { xmclAuth } from "../middleware/xmclAuth.ts";
+import type { AppEnv } from "../types.ts";
+
+interface LlmPoolEntry {
+  endpoint: string;
+  model: string;
+  key: string;
+}
+
+type LlmPools = Record<string, LlmPoolEntry[]>;
+type AppConfigResolver = (c: Context<AppEnv>) => AppConfig;
+
+export function createLlmRoutes(
+  resolve: AccountRuntimeResolver = getAccountRuntime,
+  resolveConfig: AppConfigResolver = getConfig,
+) {
+  const app = new Hono<AppEnv>();
+  app.onError(handleAccountError);
+
+  app.get("/.well-known/jwks.json", (c) => {
+    const service = new OfflineJwtService(resolveConfig(c));
+    c.header("Cache-Control", "public, max-age=300");
+    return c.json(service.jwks());
+  });
+
+  app.post(
+    "/v1/auth/gateway-token",
+    xmclAuth([], resolve),
+    async (c) => {
+      const principal = c.get("xmclPrincipal")!;
+      const runtime = await resolve(c);
+      const account = await runtime.accounts.requireActiveAccount(
+        principal.accountId,
+      );
+      const token = await new OfflineJwtService(resolveConfig(c)).issue({
+        accountId: principal.accountId,
+        sessionId: principal.sessionId,
+        scopes: principal.scopes,
+        tier: validTier(account.tier) ? account.tier : "free",
+      });
+      return c.json(token);
+    },
+  );
+
+  app.get("/llm-pool", async (c) => {
+    const config = resolveConfig(c);
+    const expected = config.LLM_POOL_SERVICE_SECRET;
+    if (!expected) throw new Error("LLM_POOL_SERVICE_SECRET is not set");
+    const header = serviceHeader(config.LLM_POOL_SERVICE_HEADER);
+    const supplied = c.req.header(header);
+    if (!supplied || !await secretsEqual(supplied, expected)) {
+      throw new AccountError(401, "invalid_service_secret");
+    }
+
+    if (!config.LLM_POOL_CONFIG) {
+      throw new Error("LLM_POOL_CONFIG is not set");
+    }
+
+    let pools: LlmPools;
+    try {
+      pools = JSON.parse(config.LLM_POOL_CONFIG) as LlmPools;
+    } catch {
+      throw new Error("LLM_POOL_CONFIG must be valid JSON");
+    }
+    validatePools(pools);
+    c.header("Cache-Control", "no-store");
+    return c.json(pools);
+  });
+
+  return app;
+}
+
+export default createLlmRoutes();
+
+function serviceHeader(value: string | undefined) {
+  const header = value?.trim().toLowerCase() || "x-service-secret";
+  if (!/^[a-z0-9!#$%&'*+.^_`|~-]+$/.test(header)) {
+    throw new Error("LLM_POOL_SERVICE_HEADER is invalid");
+  }
+  return header;
+}
+
+function validTier(value: string | undefined): value is string {
+  return value !== undefined && /^[a-z0-9][a-z0-9_-]{0,31}$/i.test(value);
+}
+
+function validatePools(value: LlmPools) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("LLM_POOL_CONFIG must be a tier-keyed object");
+  }
+  const tiers = Object.entries(value);
+  if (tiers.length === 0) throw new Error("LLM_POOL_CONFIG has no tiers");
+  for (const [tier, entries] of tiers) {
+    if (!validTier(tier) || !Array.isArray(entries) || entries.length === 0) {
+      throw new Error(`LLM_POOL_CONFIG tier '${tier}' is invalid`);
+    }
+    for (const entry of entries) {
+      if (
+        !entry || typeof entry !== "object" ||
+        typeof entry.endpoint !== "string" ||
+        typeof entry.model !== "string" || entry.model.length === 0 ||
+        typeof entry.key !== "string" || entry.key.length === 0
+      ) {
+        throw new Error(`LLM_POOL_CONFIG tier '${tier}' has an invalid entry`);
+      }
+      let endpoint: URL;
+      try {
+        endpoint = new URL(entry.endpoint);
+      } catch {
+        throw new Error(`LLM_POOL_CONFIG tier '${tier}' has an invalid URL`);
+      }
+      if (endpoint.protocol !== "https:") {
+        throw new Error(
+          `LLM_POOL_CONFIG tier '${tier}' endpoint must use HTTPS`,
+        );
+      }
+    }
+  }
+}
+
+async function secretsEqual(left: string, right: string) {
+  const [leftHash, rightHash] = await Promise.all([
+    crypto.subtle.digest("SHA-256", new TextEncoder().encode(left)),
+    crypto.subtle.digest("SHA-256", new TextEncoder().encode(right)),
+  ]);
+  const a = new Uint8Array(leftHash);
+  const b = new Uint8Array(rightHash);
+  let difference = 0;
+  for (let index = 0; index < a.length; index++) {
+    difference |= a[index] ^ b[index];
+  }
+  return difference === 0;
+}

--- a/src/routes/session.ts
+++ b/src/routes/session.ts
@@ -15,11 +15,13 @@ import { xmclAuth } from "../middleware/xmclAuth.ts";
 function publicAccount(account: {
   accountId: string;
   status: string;
+  tier?: string;
   createdAt: string;
 }) {
   return {
     accountId: account.accountId,
     status: account.status,
+    tier: account.tier ?? "free",
     createdAt: account.createdAt,
   };
 }


### PR DESCRIPTION
## Summary
- retain Mongo-backed XMCL sessions and exchange them for 15-minute RS256 gateway tokens
- publish JWKS with signing-key rotation support
- add service-secret-protected tiered LLM pool configuration for xmcl-ai-routing
- preserve paid tiers across account merges and require HTTPS provider endpoints
- document Cloudflare secrets and include an RSA JWK generator

## Validation
- 14 targeted Deno tests passed
- Cloudflare Worker Deno typecheck passed
- Wrangler deployment dry-run bundled successfully