### PR TITLE
chore(cloudflare): enable worker traces

### DIFF
--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -19,8 +19,8 @@
     "xxhash-wasm": "^1.1.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20240909.0",
+    "@cloudflare/workers-types": "^5.20260804.1",
     "typescript": "^5.5.0",
-    "wrangler": "^3.78.0"
+    "wrangler": "^4.119.0"
   }
 }

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -11,6 +11,10 @@ head_sampling_rate = 1
 [observability.logs]
 invocation_logs = false
 
+[observability.traces]
+enabled = true
+head_sampling_rate = 1
+
 [triggers]
 crons = ["*/5 * * * *"]
 


### PR DESCRIPTION
## Summary
- explicitly enable Cloudflare Workers traces at 100% sampling
- upgrade Wrangler and Workers types so the traces configuration is recognized

## Validation
- `npm --prefix cloudflare run typecheck`
- `deno check cloudflare/worker.ts`